### PR TITLE
ЛР-1 Бруснигин

### DIFF
--- a/src/tbitfield.cpp
+++ b/src/tbitfield.cpp
@@ -9,92 +9,220 @@
 
 #define BITS_IN_ONE_MEM (sizeof(TELEM) * 8)
 
-TBitField::TBitField(int len)
-{
 
+TBitField::TBitField(int len) : BitLen(len) {
+	if (len <= 0)
+		throw "Error";
+
+	if (BitLen % BITS_IN_ONE_MEM)
+		MemLen = BitLen / BITS_IN_ONE_MEM + 1;
+
+	else
+		MemLen = BitLen / BITS_IN_ONE_MEM;
+
+	pMem = new TELEM[MemLen];
+
+	for (int i = 0; i < MemLen; i++)
+		pMem[i] = (TELEM) 0;
+};
+
+
+TBitField::TBitField(const TBitField& bf) {  // конструктор копирования
+	BitLen = bf.BitLen;
+	MemLen = bf.MemLen;
+	pMem = new TELEM[MemLen];
+
+	for (int i = 0; i < MemLen; i++) {
+		pMem[i] = bf.pMem[i];
+	}
 }
 
-TBitField::TBitField(const TBitField& bf) // конструктор копирования
-{
+
+TBitField::~TBitField() {
+	delete[] pMem;
+	pMem = nullptr;
 }
 
-TBitField::~TBitField()
-{
+
+int TBitField::GetMemIndex(const int n) const {  // индекс Мем для бита n
+	if ((n < 0) || (n >= BitLen)) {
+		throw "Error";
+	}
+
+ 	return n / (BITS_IN_ONE_MEM);
 }
 
-int TBitField::GetMemIndex(const int n) const // индекс Мем для бита n
-{
- return 0;
-}
 
-TELEM TBitField::GetMemMask(const int n) const // битовая маска для бита n
-{
+TELEM TBitField::GetMemMask(const int n) const {  // битовая маска для бита n
+	if ((n < 0) || (n >= BitLen)) {
+		throw "Error";
+	}
 
-	return 0;
+	return ((TELEM)1 << (n % BITS_IN_ONE_MEM));
 }
 
 // доступ к битам битового поля
 
-int TBitField::GetLength(void) const // получить длину (к-во битов)
-{
-	return 0;
+int TBitField::GetLength(void) const {  // получить длину (к-во битов)
+	return BitLen;
 }
 
-void TBitField::SetBit(const int n) // установить бит
-{
-	if ((n < 0) || (n > BitLen))
-		throw 2;
+
+void TBitField::SetBit(const int n) {  // установить бит
+	if ((n < 0) || (n >= BitLen)) {
+		throw "Error";
+	}
+	pMem[GetMemIndex(n)] |= GetMemMask(n);
+} 
+
+
+void TBitField::ClrBit(const int n) {  // очистить бит
+	if ((n < 0) || (n >= BitLen)) {
+		throw "Error";
+	}
+	pMem[GetMemIndex(n)] &= ~GetMemMask(n);
 }
 
-void TBitField::ClrBit(const int n) // очистить бит
-{
+
+int TBitField::GetBit(const int n) const {  // получить значение бита
+	if ((n < 0) || (n >= BitLen)) {
+		throw "Error";
+	}
+
+	return ((pMem[GetMemIndex(n)] & GetMemMask(n)) != 0);
 }
 
-int TBitField::GetBit(const int n) const // получить значение бита
-{
-	return 0;
-}
 
 // битовые операции
 
-TBitField& TBitField::operator=(const TBitField & bf) // присваивание
-{
+TBitField& TBitField::operator=(const TBitField & bf) {  // присваивание
+	if (this != &bf) {
+		MemLen = bf.MemLen;
+		BitLen = bf.BitLen;
+
+		delete[] pMem;
+		pMem = new TELEM[MemLen];
+
+		for (int i = 0; i < MemLen; i++) {
+			pMem[i] = bf.pMem[i];
+		}
+	}
 	return *this;
 }
 
-int TBitField::operator==(const TBitField & bf) const // сравнение
-{
+
+int TBitField::operator==(const TBitField & bf) const {  // сравнение
+	if ((bf.BitLen == BitLen)) {
+		for (int i = 0; i < bf.MemLen; i++) {
+			if (pMem[i] != bf.pMem[i]) {
+				return 0;
+			}
+		}
+		return 1;
+	}
 	return 0;
 }
 
-int TBitField::operator!=(const TBitField & bf) const // сравнение
-{
-	return 0;
+
+int TBitField::operator!=(const TBitField & bf) const {  // сравнение
+	if (bf.BitLen == BitLen) {
+		for (int i = 0; i < bf.MemLen; i++) {
+			if (pMem[i] != bf.pMem[i]) {
+				return 1;
+			}
+		}
+		return 0;
+	}
+	return 1;
 }
 
-TBitField TBitField::operator|(const TBitField & bf) // операция "или"
-{
-	return TBitField(0);
+
+TBitField TBitField::operator|(const TBitField & bf) {  // операция "или"
+	const TBitField* bigger;
+	const TBitField* smaller;
+
+	if (BitLen >= bf.BitLen) {
+		bigger = this;
+		smaller = &bf;
+	}
+
+	else {
+		bigger = &bf;
+		smaller = this;
+	}
+
+	TBitField result(*bigger);
+
+	for (int i = 0; i < smaller->MemLen; i++)
+		result.pMem[i] = bigger->pMem[i] | smaller->pMem[i];
+
+	return result;
 }
 
-TBitField TBitField::operator&(const TBitField & bf) // операция "и"
-{
-	return TBitField(0);
+
+TBitField TBitField::operator&(const TBitField & bf) {  // операция "и"
+	const TBitField* bigger;
+	const TBitField* smaller;
+
+	if (BitLen >= bf.BitLen) {
+		bigger = this;
+		smaller = &bf;
+	}
+
+	else {
+		bigger = &bf;
+		smaller = this;
+	}
+
+	TBitField result(bigger->BitLen);
+
+	for (int i = 0; i < smaller->MemLen - 1; i++)
+		result.pMem[i] = bigger->pMem[i] & smaller->pMem[i];
+
+	if (MemLen >= 1)
+		for (int i = (smaller->MemLen - 1)*BITS_IN_ONE_MEM; i < smaller->BitLen; i++)
+			if (bigger->GetBit(i)*smaller->GetBit(i))
+				result.SetBit(i);
+
+	return result;
 }
 
-TBitField TBitField::operator~(void) // отрицание
-{
-  return TBitField(0);
+
+TBitField TBitField::operator~(void) {  // отрицание
+	TBitField result(*this);
+
+	for (int i = 0; i < MemLen - 1; i++)
+		result.pMem[i] = ~pMem[i];
+
+	if (MemLen >= 1)
+		for (int i = (MemLen - 1)*BITS_IN_ONE_MEM; i < result.BitLen; i++) {
+			if (GetBit(i)) {
+				result.ClrBit(i);
+			}
+
+			else {
+				result.SetBit(i);
+			}
+		}
+
+	return result;
 }
+
 
 // ввод/вывод
 
-istream& operator>>(istream & istr, TBitField & bf) // ввод
-{
-  return istr;
+istream& operator>>(istream & istr, TBitField & bf) {  // ввод
+	int k;
+	istr >> k;
+	bf = TBitField(k);
+
+  	return istr;
 }
 
-ostream& operator<<(ostream & ostr, const TBitField & bf) // вывод
-{
+
+ostream& operator<<(ostream & ostr, const TBitField & bf) {  // вывод
+	for (int i = 0; i < bf.BitLen; i++) {
+		ostr << bf.GetBit(i) << " ";
+	}
 	return ostr;
 }

--- a/src/tset.cpp
+++ b/src/tset.cpp
@@ -7,95 +7,128 @@
 
 #include "tset.h"
 
-TSet::TSet(int mp) : BitField(mp)
-{
-
+TSet::TSet(int mp) : BitField(mp) {
+    MaxPower = mp;
+    BitField = TBitField(mp);
 }
 
 // конструктор копирования
-TSet::TSet(const TSet& s) : BitField(0)
-{
+TSet::TSet(const TSet& s) : BitField(s.BitField) {
+    MaxPower = s.MaxPower;
 }
 
 // конструктор преобразования типа
-TSet::TSet(const TBitField& bf) : BitField(0)
-{
-}
+TSet::TSet(const TBitField& bf) : BitField(bf) {
+    MaxPower = bf.GetLength();
+};
 
-TSet::operator TBitField()
-{
+TSet::operator TBitField() {
 	return BitField;
 }
 
-int TSet::GetMaxPower(void) const // получить макс. к-во эл-тов
-{
-	return MaxPower;
+int TSet::GetMaxPower(void) const {
+    return MaxPower;
 }
 
-int TSet::IsMember(const int Elem) const // элемент множества?
-{
-	return 0;
+int TSet::IsMember(const int Elem) const {  // элемент множества?
+	return BitField.GetBit(Elem);
 }
 
-void TSet::InsElem(const int Elem) // включение элемента множества
-{
+void TSet::InsElem(const int Elem) {  // включение элемента множества
+    BitField.SetBit(Elem);
 }
 
-void TSet::DelElem(const int Elem) // исключение элемента множества
-{
+void TSet::DelElem(const int Elem) {  // исключение элемента множества
+    BitField.ClrBit(Elem);
 }
 
 // теоретико-множественные операции
 
-TSet& TSet::operator=(const TSet& s) // присваивание
-{
+TSet& TSet::operator=(const TSet& s) {  // присваивание
+    if (this != &s) {
+		MaxPower = s.MaxPower;
+		BitField = s.BitField;
+    }
+
 	return *this;
 }
 
-int TSet::operator==(const TSet& s) const // сравнение
-{
-	return 0;
+int TSet::operator==(const TSet& s) const {  // сравнение
+    if (this != &s) {
+        if (MaxPower == s.MaxPower && BitField == s.BitField) {
+            return 1;
+        }
+        else {
+            return 0;
+        }
+    }
+	return 1;
 }
 
-int TSet::operator!=(const TSet& s) const // сравнение
-{
-  return 0;
+int TSet::operator!=(const TSet& s) const {  // сравнение
+    if (this != &s){
+        if (MaxPower != s.MaxPower || BitField != s.BitField) {
+            return 1;
+        }
+        else {
+            return 0;
+        }
+    }
+    return 0;
 }
 
-TSet TSet::operator+(const TSet& s) // объединение
-{
-  return TSet(0);
+TSet TSet::operator+(const TSet& s) {  // объединение
+    TBitField res(MaxPower);
+    res = BitField | s.BitField;
+
+    return res;
 }
 
-TSet TSet::operator+(const int Elem) // объединение с элементом
-{
-
-  return TSet(0);
+TSet TSet::operator+(const int Elem) {  // объединение с элементом
+    TSet res(*this);
+	res.InsElem(Elem);
+	return res;
 }
 
-TSet TSet::operator-(const int Elem) // разность с элементом
-{
-  return TSet(0);
+TSet TSet::operator-(const int Elem) {  // разность с элементом
+    TSet res(*this);
+	res.DelElem(Elem);
+	return res;
 }
 
-TSet TSet::operator*(const TSet& s) // пересечение
-{
-  return TSet(0);
+TSet TSet::operator*(const TSet& s) {  // пересечение
+    int mp = s.GetMaxPower();
+
+    if (MaxPower > mp) {
+        mp = MaxPower;
+    }
+
+    TSet res(mp);
+
+    res.BitField = BitField & s.BitField;
+    return res;
 }
 
-TSet TSet::operator~(void) // дополнение
-{
-  return TSet(0);
+TSet TSet::operator~(void) {  // дополнение
+    TSet res(MaxPower);
+    res.BitField = ~BitField;
+    return res;
 }
 
 // перегрузка ввода/вывода
 
-istream& operator>>(istream& istr, TSet& s) // ввод
-{
-  return istr;
+istream& operator>>(istream& istr, TSet& s) {  // ввод
+    for(int i = 0; i < s.MaxPower; i++) {
+		istr >> s.BitField;
+	}
+
+	return istr;
 }
 
-ostream& operator<<(ostream& ostr, const TSet& s) // вывод
-{
+ostream& operator<<(ostream& ostr, const TSet& s) {  // вывод
+    for(int i = 0; i < s.MaxPower; i++) {
+		ostr << s.BitField << " ";
+	}
+
 	return ostr;
 }


### PR DESCRIPTION
Анна Юрьевна, по моему я нашёл конфликт между двумя тестами для TBitField: _and_operator_applied_to_bitfields_of_non_equal_size_ и _invert_plus_and_operator_on_different_size_bitfield_.

Они оба связаны с пересечением двух разных по длине полей. Первый тест предполагает, что та **часть** большего поля, до которой не достаёт меньшее поле, будет просто заполнена нулями (мы как бы мысленно дополняем меньшее поле нулями до размера большего). Второй тест предполагает, что мы оставляем эту часть без изменений